### PR TITLE
Add ErrorStack capability

### DIFF
--- a/src/main/scala/scynamo/generic/GenericEnumScynamoDecoder.scala
+++ b/src/main/scala/scynamo/generic/GenericEnumScynamoDecoder.scala
@@ -1,7 +1,8 @@
 package scynamo.generic
 
-import cats.syntax.either._
 import cats.data.EitherNec
+import cats.syntax.either._
+import scynamo.StackFrame.Enum
 import scynamo.{ScynamoDecodeError, ScynamoDecoder, ScynamoType}
 import shapeless._
 import shapeless.labelled._
@@ -26,7 +27,7 @@ object ShapelessScynamoEnumDecoder extends EnumDecoderCoproductInstances
 
 trait EnumDecoderCoproductInstances {
   import scynamo.syntax.attributevalue._
-  implicit val deriveCNil: ShapelessScynamoEnumDecoder[CNil] = value => Either.leftNec(ScynamoDecodeError.InvalidCoproductCaseAttr(value))
+  implicit val deriveCNil: ShapelessScynamoEnumDecoder[CNil] = value => Either.leftNec(ScynamoDecodeError.invalidCoproductCaseAttr(value))
 
   implicit def deriveCCons[K <: Symbol, V, T <: Coproduct](
       implicit
@@ -37,7 +38,7 @@ trait EnumDecoderCoproductInstances {
     if (attributeValue.asOption(ScynamoType.String).contains(key.value.name)) {
       Right(Inl(field[K](sv.from(HNil))))
     } else {
-      st.value.decode(attributeValue).map(Inr(_))
+      st.value.decode(attributeValue).map(Inr(_)).leftMap(_.map(_.push(Enum(key.value.name))))
     }
   }
 }

--- a/src/main/scala/scynamo/syntax/attributevalue/AttributeValueDslOps.scala
+++ b/src/main/scala/scynamo/syntax/attributevalue/AttributeValueDslOps.scala
@@ -5,7 +5,7 @@ import java.util
 import cats.syntax.either._
 import cats.data.NonEmptyChain
 import scynamo.ScynamoDecodeError.TypeMismatch
-import scynamo.ScynamoType
+import scynamo.{ScynamoDecodeError, ScynamoType}
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
@@ -40,7 +40,7 @@ class AttributeValueDslOps(val attributeValue: AttributeValue) extends AnyVal {
 
   def asEither[A, R](typ: ScynamoType.Aux[R]): Either[NonEmptyChain[TypeMismatch], R] =
     attributeValue.asOption(typ) match {
-      case None        => Either.leftNec(TypeMismatch(typ, attributeValue))
+      case None        => Either.leftNec(ScynamoDecodeError.typeMismatch(typ, attributeValue))
       case Some(value) => Right(value)
     }
 }

--- a/src/test/scala/scynamo/ScynamoCodecTest.scala
+++ b/src/test/scala/scynamo/ScynamoCodecTest.scala
@@ -1,9 +1,8 @@
 package scynamo
 
-import org.scalatest.Inspectors
-import scynamo.ScynamoDecodeError.GeneralError
-import scynamo.syntax.encoder._
 import cats.data.NonEmptyChain
+import org.scalatest.Inspectors
+import scynamo.syntax.encoder._
 
 class ScynamoCodecTest extends UnitTest {
   "ScynamoCodec" should {
@@ -82,7 +81,7 @@ class ScynamoCodecTest extends UnitTest {
       case object Foo extends Foobar
       case object Bar extends Foobar
 
-      val error = NonEmptyChain.one(GeneralError(s"Unknown tag", None))
+      val error = NonEmptyChain.one(ScynamoDecodeError.generalError(s"Unknown tag", None))
       val codec = ScynamoCodec[String].itransform[Foobar] {
         case Left(value) => Left(value)
         case Right(value) =>


### PR DESCRIPTION
This gives much better errors if decoding fails by pointing you to the exact attribute that failed.  Example:

```
ErrorStack(Attr(intermediateTripState) -> Case(IntermediateCompleted) -> Attr(offer) -> Attr(requestTime))
```

Currently `scynamo` supports three frame types: `Attr` when accessing an attribute, `Case` when chosing a case of a sealed trait and `Enum` when trying to decode sth as an `case object` (EnumCodec)