### PR TITLE
Use Xsource:3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,8 @@ lazy val scalacOptions_2_13 = Seq(
   "-Xfatal-warnings",
   "-Ywarn-dead-code",
   "-Ymacro-annotations",
-  "-Xlint:_,-byname-implicit"
+  "-Xlint:_,-byname-implicit",
+  "-Xsource:3"
 )
 
 lazy val sbtVersionRegex = "v([0-9]+.[0-9]+.[0-9]+)-?(.*)?".r

--- a/src/main/scala/scynamo/generic/semiauto.scala
+++ b/src/main/scala/scynamo/generic/semiauto.scala
@@ -1,9 +1,9 @@
 package scynamo.generic
 
-import scynamo.{ObjectScynamoCodec, ObjectScynamoDecoder, ObjectScynamoEncoder, ScynamoDecoder, ScynamoEncoder, ScynamoEnumCodec}
+import scynamo._
 import shapeless.Lazy
 
-package object semiauto extends SemiautoDerivation
+object semiauto extends SemiautoDerivation
 
 trait SemiautoDerivation extends SemiautoDerivationEncoder with SemiautoDerivationDecoder with SemiautoDerivationCodec
 

--- a/src/main/scala/scynamo/syntax/AttributeValueDslOps.scala
+++ b/src/main/scala/scynamo/syntax/AttributeValueDslOps.scala
@@ -1,19 +1,21 @@
-package scynamo.syntax.attributevalue
+package scynamo.syntax
 
-import java.util
-
-import cats.syntax.either._
 import cats.data.NonEmptyChain
+import cats.syntax.either._
 import scynamo.ScynamoDecodeError.TypeMismatch
 import scynamo.{ScynamoDecodeError, ScynamoType}
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
+import java.util
+
+object attributevalue extends AttributeValueDsl
+
 trait AttributeValueDsl {
   implicit def toAttributeValueOps(attributeValue: AttributeValue): AttributeValueDslOps = new AttributeValueDslOps(attributeValue)
 }
 
-class AttributeValueDslOps(val attributeValue: AttributeValue) extends AnyVal {
+class AttributeValueDslOps(val attributeValue: AttributeValue) extends AttributeValueDsl {
   private[this] def nulOpt: Option[Boolean]                        = Option(attributeValue.nul).map(_.booleanValue)
   private[this] def bOpt: Option[SdkBytes]                         = Option(attributeValue.b)
   private[this] def nOpt: Option[String]                           = Option(attributeValue.n)

--- a/src/main/scala/scynamo/syntax/AttributeValueDslOps.scala
+++ b/src/main/scala/scynamo/syntax/AttributeValueDslOps.scala
@@ -3,6 +3,7 @@ package scynamo.syntax
 import cats.data.NonEmptyChain
 import cats.syntax.either._
 import scynamo.ScynamoDecodeError.TypeMismatch
+import scynamo.syntax.all.toAttributeValueOps
 import scynamo.{ScynamoDecodeError, ScynamoType}
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
@@ -15,7 +16,7 @@ trait AttributeValueDsl {
   implicit def toAttributeValueOps(attributeValue: AttributeValue): AttributeValueDslOps = new AttributeValueDslOps(attributeValue)
 }
 
-class AttributeValueDslOps(val attributeValue: AttributeValue) extends AttributeValueDsl {
+class AttributeValueDslOps(val attributeValue: AttributeValue) extends AnyVal {
   private[this] def nulOpt: Option[Boolean]                        = Option(attributeValue.nul).map(_.booleanValue)
   private[this] def bOpt: Option[SdkBytes]                         = Option(attributeValue.b)
   private[this] def nOpt: Option[String]                           = Option(attributeValue.n)

--- a/src/main/scala/scynamo/syntax/ScynamoDecoderDslOps.scala
+++ b/src/main/scala/scynamo/syntax/ScynamoDecoderDslOps.scala
@@ -1,4 +1,4 @@
-package scynamo.syntax.decoder
+package scynamo.syntax
 
 import cats.data.EitherNec
 import scynamo.{ObjectScynamoDecoder, ScynamoDecodeError, ScynamoDecoder}
@@ -19,3 +19,5 @@ trait ScynamoDecoderDsl {
   implicit def toObjectScynamoDecoderDsl(attributeValueMap: java.util.Map[String, AttributeValue]): ObjectScynamoDecoderDslOps =
     new ObjectScynamoDecoderDslOps(attributeValueMap)
 }
+
+object decoder extends ScynamoDecoderDsl

--- a/src/main/scala/scynamo/syntax/ScynamoEncoderDslOps.scala
+++ b/src/main/scala/scynamo/syntax/ScynamoEncoderDslOps.scala
@@ -1,10 +1,10 @@
-package scynamo.syntax.encoder
-
-import java.util
+package scynamo.syntax
 
 import cats.data.EitherNec
 import scynamo.{ObjectScynamoEncoder, ScynamoEncodeError, ScynamoEncoder}
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+
+import java.util
 
 class ScynamoEncoderDslOps[A](val value: A) extends AnyVal {
   def encoded(implicit encoder: ScynamoEncoder[A]): EitherNec[ScynamoEncodeError, AttributeValue] = encoder.encode(value)
@@ -27,3 +27,5 @@ class ScynamoEncoderDslOps[A](val value: A) extends AnyVal {
 trait ScynamoEncoderDsl {
   implicit def toScynamoEncoderDslOps[A: ScynamoEncoder](value: A): ScynamoEncoderDslOps[A] = new ScynamoEncoderDslOps(value)
 }
+
+object encoder extends ScynamoEncoderDsl

--- a/src/main/scala/scynamo/syntax/all.scala
+++ b/src/main/scala/scynamo/syntax/all.scala
@@ -1,0 +1,3 @@
+package scynamo.syntax
+
+object all extends ScynamoEncoderDsl with ScynamoDecoderDsl with AttributeValueDsl

--- a/src/main/scala/scynamo/syntax/all/package.scala
+++ b/src/main/scala/scynamo/syntax/all/package.scala
@@ -1,7 +1,0 @@
-package scynamo.syntax
-
-import scynamo.syntax.attributevalue.AttributeValueDsl
-import scynamo.syntax.decoder.ScynamoDecoderDsl
-import scynamo.syntax.encoder.ScynamoEncoderDsl
-
-package object all extends ScynamoEncoderDsl with ScynamoDecoderDsl with AttributeValueDsl

--- a/src/main/scala/scynamo/syntax/attributevalue/package.scala
+++ b/src/main/scala/scynamo/syntax/attributevalue/package.scala
@@ -1,3 +1,0 @@
-package scynamo.syntax
-
-package object attributevalue extends AttributeValueDsl

--- a/src/main/scala/scynamo/syntax/codec.scala
+++ b/src/main/scala/scynamo/syntax/codec.scala
@@ -1,0 +1,3 @@
+package scynamo.syntax
+
+object codec extends ScynamoEncoderDsl with ScynamoDecoderDsl

--- a/src/main/scala/scynamo/syntax/codec/package.scala
+++ b/src/main/scala/scynamo/syntax/codec/package.scala
@@ -1,6 +1,0 @@
-package scynamo.syntax
-
-import scynamo.syntax.decoder.ScynamoDecoderDsl
-import scynamo.syntax.encoder.ScynamoEncoderDsl
-
-package object codec extends ScynamoEncoderDsl with ScynamoDecoderDsl

--- a/src/main/scala/scynamo/syntax/decoder/package.scala
+++ b/src/main/scala/scynamo/syntax/decoder/package.scala
@@ -1,3 +1,0 @@
-package scynamo.syntax
-
-package object decoder extends ScynamoDecoderDsl

--- a/src/main/scala/scynamo/syntax/encoder/package.scala
+++ b/src/main/scala/scynamo/syntax/encoder/package.scala
@@ -1,3 +1,0 @@
-package scynamo.syntax
-
-package object encoder extends ScynamoEncoderDsl


### PR DESCRIPTION
Scala 3 is deprecating package objects with inheritance (see https://github.com/scala/scala-dev/issues/441). We were using them quite a lot.
This uses the compiler flag `-Xsource:3` to err on features deprecated in Scala 3 and changes package objects to normal objects which requires some shifting of files to keep the imports stable.
This is the first PR of many to support Scala 3.