### PR TITLE
Allow modifying encoded maps and objects

### DIFF
--- a/src/main/scala/scynamo/ScynamoEncoder.scala
+++ b/src/main/scala/scynamo/ScynamoEncoder.scala
@@ -12,7 +12,7 @@ import shapeless.tag.@@
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 import java.time.Instant
-import java.util.{Collections, UUID}
+import java.util.UUID
 import scala.collection.compat._
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -197,7 +197,7 @@ object ObjectScynamoEncoder extends SemiautoDerivationEncoder {
         }
       }
 
-      NonEmptyChain.fromChain(allErrors).toLeft(Collections.unmodifiableMap(attrValues))
+      NonEmptyChain.fromChain(allErrors).toLeft(attrValues)
     }
 }
 

--- a/src/main/scala/scynamo/generic/GenericScynamoEncoder.scala
+++ b/src/main/scala/scynamo/generic/GenericScynamoEncoder.scala
@@ -3,8 +3,6 @@ package scynamo.generic
 import scynamo.ObjectScynamoEncoder
 import shapeless.{LabelledGeneric, Lazy}
 
-import java.util.Collections
-
 trait GenericScynamoEncoder[A] extends ObjectScynamoEncoder[A]
 
 object GenericScynamoEncoder extends GenericScynamoEncoderInstances
@@ -14,5 +12,5 @@ trait GenericScynamoEncoderInstances {
       gen: LabelledGeneric.Aux[F, G],
       sg: Lazy[ShapelessScynamoEncoder[F, G]]
   ): GenericScynamoEncoder[F] =
-    value => sg.value.encodeMap(gen.to(value)).map(Collections.unmodifiableMap(_))
+    value => sg.value.encodeMap(gen.to(value))
 }


### PR DESCRIPTION
Maybe a bit controversial - in #247 I returned `Collections.unmodifiableMap` but later I realised that it's a perfectly valid use case to modify this map while building a larger encoder from smaller parts and in fact we do this in one place already.