### PR TITLE
Add support for java.time.YearMonth

### DIFF
--- a/src/main/scala/scynamo/ScynamoDecoder.scala
+++ b/src/main/scala/scynamo/ScynamoDecoder.scala
@@ -184,8 +184,6 @@ trait DefaultScynamoDecoderInstances extends ScynamoDecoderFunctions with Scynam
 trait ScynamoIterableDecoder extends LowestPrioAutoDecoder {
   import scynamo.syntax.attributevalue._
 
-  import scala.language.higherKinds
-
   def iterableDecoder[A, C[_] <: Iterable[_]](implicit element: ScynamoDecoder[A], factory: Factory[A, C[A]]): ScynamoDecoder[C[A]] =
     ScynamoDecoder.instance(_.asEither(ScynamoType.List).flatMap { attributes =>
       var allErrors = Chain.empty[ScynamoDecodeError]

--- a/src/main/scala/scynamo/ScynamoDecoder.scala
+++ b/src/main/scala/scynamo/ScynamoDecoder.scala
@@ -12,6 +12,7 @@ import shapeless.tag.@@
 import shapeless.{tag, Lazy}
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
+import java.time.format.DateTimeFormatter
 import java.time.{Instant, YearMonth}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -141,8 +142,12 @@ trait DefaultScynamoDecoderInstances extends ScynamoDecoderFunctions with Scynam
   implicit val durationDecoder: ScynamoDecoder[Duration] =
     longDecoder.map(Duration(_, TimeUnit.NANOSECONDS))
 
+  /** Using a custom formatter because
+    * "Years outside the range 0000 to 9999 must be prefixed by the plus or minus symbol."
+    * but the plus symbol is not added by the default `.toString`.
+    */
   implicit val yearMonthDecoder: ScynamoDecoder[YearMonth] =
-    stringDecoder.map(YearMonth.parse)
+    stringDecoder.map(YearMonth.parse(_, DateTimeFormatter.ofPattern("uuuu-MM")))
 
   implicit val uuidDecoder: ScynamoDecoder[UUID] =
     ScynamoDecoder.instance(_.asEither(ScynamoType.String).flatMap(convert(_, "UUID")(UUID.fromString)))

--- a/src/main/scala/scynamo/ScynamoDecoder.scala
+++ b/src/main/scala/scynamo/ScynamoDecoder.scala
@@ -12,7 +12,7 @@ import shapeless.tag.@@
 import shapeless.{tag, Lazy}
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
-import java.time.Instant
+import java.time.{Instant, YearMonth}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
@@ -39,8 +39,8 @@ trait ScynamoDecoder[A] extends ScynamoDecoderFunctions { self =>
   def defaultValue: Option[A] = None
 
   def withDefault(value: A): ScynamoDecoder[A] = new ScynamoDecoder[A] {
-    override def decode(attributeValue: AttributeValue) = self.decode(attributeValue)
-    override val defaultValue                           = Some(value)
+    override def decode(attributeValue: AttributeValue): EitherNec[ScynamoDecodeError, A] = self.decode(attributeValue)
+    override val defaultValue: Option[A]                                                  = Some(value)
   }
 }
 
@@ -141,6 +141,9 @@ trait DefaultScynamoDecoderInstances extends ScynamoDecoderFunctions with Scynam
   implicit val durationDecoder: ScynamoDecoder[Duration] =
     longDecoder.map(Duration(_, TimeUnit.NANOSECONDS))
 
+  implicit val yearMonthDecoder: ScynamoDecoder[YearMonth] =
+    stringDecoder.map(YearMonth.parse)
+
   implicit val uuidDecoder: ScynamoDecoder[UUID] =
     ScynamoDecoder.instance(_.asEither(ScynamoType.String).flatMap(convert(_, "UUID")(UUID.fromString)))
 
@@ -170,9 +173,9 @@ trait DefaultScynamoDecoderInstances extends ScynamoDecoderFunctions with Scynam
 
   implicit def fieldDecoder[K, V](implicit V: Lazy[ScynamoDecoder[V]]): ScynamoDecoder[FieldType[K, V]] =
     new ScynamoDecoder[FieldType[K, V]] {
-      override def decode(attributeValue: AttributeValue) =
+      override def decode(attributeValue: AttributeValue): EitherNec[ScynamoDecodeError, FieldType[K, V]] =
         V.value.decode(attributeValue).map(field[K][V])
-      override lazy val defaultValue =
+      override lazy val defaultValue: Option[FieldType[K, V]] =
         V.value.defaultValue.map(field[K][V])
     }
 }
@@ -180,7 +183,9 @@ trait DefaultScynamoDecoderInstances extends ScynamoDecoderFunctions with Scynam
 trait ScynamoIterableDecoder extends LowestPrioAutoDecoder {
   import scynamo.syntax.attributevalue._
 
-  def iterableDecoder[A, C[x] <: Iterable[x]](implicit element: ScynamoDecoder[A], factory: Factory[A, C[A]]): ScynamoDecoder[C[A]] =
+  import scala.language.higherKinds
+
+  def iterableDecoder[A, C[_] <: Iterable[_]](implicit element: ScynamoDecoder[A], factory: Factory[A, C[A]]): ScynamoDecoder[C[A]] =
     ScynamoDecoder.instance(_.asEither(ScynamoType.List).flatMap { attributes =>
       var allErrors = Chain.empty[ScynamoDecodeError]
       val allValues = factory.newBuilder

--- a/src/main/scala/scynamo/ScynamoEncoder.scala
+++ b/src/main/scala/scynamo/ScynamoEncoder.scala
@@ -6,12 +6,12 @@ import cats.syntax.all._
 import scynamo.StackFrame.{Index, MapKey}
 import scynamo.generic.auto.AutoDerivationUnlocked
 import scynamo.generic.{GenericScynamoEncoder, SemiautoDerivationEncoder}
+import scynamo.wrapper.YearMonthFormatter.yearMonthFormatter
 import shapeless._
 import shapeless.labelled.FieldType
 import shapeless.tag.@@
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
-import java.time.format.DateTimeFormatter
 import java.time.{Instant, YearMonth}
 import java.util.{Collections, UUID}
 import scala.collection.compat._
@@ -110,12 +110,8 @@ trait DefaultScynamoEncoderInstances extends ScynamoIterableEncoder {
   implicit val durationEncoder: ScynamoEncoder[Duration] =
     numberStringEncoder.contramap(_.toNanos.toString)
 
-  /** Using a custom formatter because
-    * "Years outside the range 0000 to 9999 must be prefixed by the plus or minus symbol."
-    * but the plus symbol is not added by the default `.toString`.
-    */
   implicit val yearMonthEncoder: ScynamoEncoder[YearMonth] =
-    stringEncoder.contramap(_.format(DateTimeFormatter.ofPattern("uuuu-MM")))
+    stringEncoder.contramap(_.format(yearMonthFormatter))
 
   implicit def mapEncoder[A, B](implicit key: ScynamoKeyEncoder[A], value: ScynamoEncoder[B]): ScynamoEncoder[Map[A, B]] =
     ScynamoEncoder.instance { kvs =>

--- a/src/main/scala/scynamo/ScynamoEncoder.scala
+++ b/src/main/scala/scynamo/ScynamoEncoder.scala
@@ -11,6 +11,7 @@ import shapeless.labelled.FieldType
 import shapeless.tag.@@
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
+import java.time.format.DateTimeFormatter
 import java.time.{Instant, YearMonth}
 import java.util.{Collections, UUID}
 import scala.collection.compat._
@@ -109,8 +110,12 @@ trait DefaultScynamoEncoderInstances extends ScynamoIterableEncoder {
   implicit val durationEncoder: ScynamoEncoder[Duration] =
     numberStringEncoder.contramap(_.toNanos.toString)
 
+  /** Using a custom formatter because
+    * "Years outside the range 0000 to 9999 must be prefixed by the plus or minus symbol."
+    * but the plus symbol is not added by the default `.toString`.
+    */
   implicit val yearMonthEncoder: ScynamoEncoder[YearMonth] =
-    stringEncoder.contramap(_.toString)
+    stringEncoder.contramap(_.format(DateTimeFormatter.ofPattern("uuuu-MM")))
 
   implicit def mapEncoder[A, B](implicit key: ScynamoKeyEncoder[A], value: ScynamoEncoder[B]): ScynamoEncoder[Map[A, B]] =
     ScynamoEncoder.instance { kvs =>

--- a/src/main/scala/scynamo/wrapper/YearMonthFormatter.scala
+++ b/src/main/scala/scynamo/wrapper/YearMonthFormatter.scala
@@ -1,0 +1,11 @@
+package scynamo.wrapper
+
+import java.time.format.DateTimeFormatter
+
+/** This is a custom formatter for `YearMonth` because
+  * "Years outside the range 0000 to 9999 must be prefixed by the plus or minus symbol."
+  * but the plus symbol is not added by the default `.toString`.
+  */
+object YearMonthFormatter {
+  final val yearMonthFormatter = DateTimeFormatter.ofPattern("uuuu-MM")
+}

--- a/src/main/scala/scynamo/wrapper/YearMonthFormatter.scala
+++ b/src/main/scala/scynamo/wrapper/YearMonthFormatter.scala
@@ -6,6 +6,6 @@ import java.time.format.DateTimeFormatter
   * "Years outside the range 0000 to 9999 must be prefixed by the plus or minus symbol."
   * but the plus symbol is not added by the default `.toString`.
   */
-object YearMonthFormatter {
+private[scynamo] object YearMonthFormatter {
   final val yearMonthFormatter = DateTimeFormatter.ofPattern("uuuu-MM")
 }

--- a/src/test/scala/scynamo/ScynamoCodecProps.scala
+++ b/src/test/scala/scynamo/ScynamoCodecProps.scala
@@ -7,7 +7,7 @@ import scynamo.generic.semiauto._
 import scynamo.wrapper.{ScynamoNumberSet, ScynamoStringSet}
 import shapeless.tag
 
-import java.time.Instant
+import java.time.{Instant, YearMonth}
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 import scala.concurrent.duration.Duration
@@ -22,15 +22,25 @@ class ScynamoCodecProps extends Properties("ScynamoCodec") {
     suffix <- Gen.nonEmptyListOf(Gen.numChar).map(_.mkString)
   } yield BigDecimal(s"$prefix.$suffix")
 
-  propertyWithSeed("decode.encode === id (int)", propertySeed) = Prop.forAll { value: Int => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (int)", propertySeed) = Prop.forAll { value: Int =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
-  propertyWithSeed("decode.encode === id (long)", propertySeed) = Prop.forAll { value: Long => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (long)", propertySeed) = Prop.forAll { value: Long =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
-  propertyWithSeed("decode.encode === id (BigInt)", propertySeed) = Prop.forAll { value: BigInt => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (BigInt)", propertySeed) = Prop.forAll { value: BigInt =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
-  propertyWithSeed("decode.encode === id (float)", propertySeed) = Prop.forAll { value: Float => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (float)", propertySeed) = Prop.forAll { value: Float =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
-  propertyWithSeed("decode.encode === id (double)", propertySeed) = Prop.forAll { value: Double => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (double)", propertySeed) = Prop.forAll { value: Double =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
   propertyWithSeed("decode.encode === id (BigDecimal)", propertySeed) = Prop.forAll { value: BigDecimal =>
     decodeAfterEncodeIsIdentity(value)
@@ -41,7 +51,9 @@ class ScynamoCodecProps extends Properties("ScynamoCodec") {
 
   property("decode.encode === id (empty string)") = decodeAfterEncodeIsIdentity("")
 
-  propertyWithSeed("decode.encode === id (boolean)", propertySeed) = Prop.forAll { value: Boolean => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (boolean)", propertySeed) = Prop.forAll { value: Boolean =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
   propertyWithSeed("decode.encode === id (instant)", propertySeed) = Prop.forAll(Gen.calendar.map(_.toInstant)) { value: Instant =>
     decodeAfterEncodeIsIdentity(value)
@@ -56,11 +68,17 @@ class ScynamoCodecProps extends Properties("ScynamoCodec") {
     decodeAfterEncodeIsIdentity(value)
   }
 
-  propertyWithSeed("decode.encode === id (list)", propertySeed) = Prop.forAll { value: List[Int] => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (list)", propertySeed) = Prop.forAll { value: List[Int] =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
-  propertyWithSeed("decode.encode === id (vector)", propertySeed) = Prop.forAll { value: Vector[Int] => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (vector)", propertySeed) = Prop.forAll { value: Vector[Int] =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
-  propertyWithSeed("decode.encode === id (set)", propertySeed) = Prop.forAll { value: Set[Int] => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (set)", propertySeed) = Prop.forAll { value: Set[Int] =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
   propertyWithSeed("decode.encode === id (option)", propertySeed) = Prop.forAll { value: Option[Int] => decodeAfterEncodeIsIdentity(value) }
 
@@ -74,6 +92,10 @@ class ScynamoCodecProps extends Properties("ScynamoCodec") {
       decodeAfterEncodeIsIdentity(Duration.fromNanos(value): Duration)
     }
 
+  propertyWithSeed("decode.encode === id (year month)", propertySeed) = Prop.forAll { value: YearMonth =>
+    decodeAfterEncodeIsIdentity(value)
+  }
+
   propertyWithSeed("decode.encode === id (case class)", propertySeed) = Prop.forAll { value: Int =>
     decodeAfterEncodeIsIdentity(ScynamoCodecProps.Foo(value))
   }
@@ -82,7 +104,9 @@ class ScynamoCodecProps extends Properties("ScynamoCodec") {
     decodeAfterEncodeIsIdentity(value)
   }
 
-  propertyWithSeed("decode.encode === id (uuid)", propertySeed) = Prop.forAll { value: UUID => decodeAfterEncodeIsIdentity(value) }
+  propertyWithSeed("decode.encode === id (uuid)", propertySeed) = Prop.forAll { value: UUID =>
+    decodeAfterEncodeIsIdentity(value)
+  }
 
   propertyWithSeed("decode.encode === id (scala map)", propertySeed) = Prop.forAll { value: Map[UUID, Int] =>
     decodeAfterEncodeIsIdentity(value)


### PR DESCRIPTION
Extracted into the library from one of our internal projects because the implementation is also quite tricky.

In cooperation with @joroKr21.

Also adding some type annotations to silence IntelliJ warnings.