### PR TITLE
Add automerge workflow to replace the Merge Me action.

### DIFF
--- a/steward-auto-merge.yaml
+++ b/steward-auto-merge.yaml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'scala-steward-for-moia[bot]' || github.actor == 'houcros' }}
+    steps:
+      - name: Enable auto-merge for Scala Steward PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Inspired on https://github.com/arturoherrero/arturoherrero.com/pull/203.
See Github docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request

Signed-off-by: Ignacio Lucero <ignacio.lucero@moia.io>
