### PR TITLE
Fix automatic merge workflow actor check.

### DIFF
--- a/.github/workflows/automatic-merge.yaml
+++ b/.github/workflows/automatic-merge.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   scala-steward-auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'scala-steward-for-moia[bot]' }}
+    if: ${{ github.actor == 'scala-steward-for-moia' }}
     steps:
       - name: Enable auto-merge for Scala Steward PRs
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Pipelines are skipping this step, e.g. https://github.com/moia-oss/scynamo/pull/437.
And I can only imagine it's because the actor check is wrong. It worked with my own
handle before.