### PR TITLE
Fix actions that require sbt

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,6 +15,7 @@ jobs:
             ~/.sbt
             ~/.cache/coursier/v1
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
+      - uses: sbt/setup-sbt@v1
       - name: Check formatting
         run: sbt scalafmtCheckAll
 
@@ -31,5 +32,6 @@ jobs:
             ~/.sbt
             ~/.cache/coursier/v1
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
+      - uses: sbt/setup-sbt@v1
       - name: Compile and test
         run: sbt docs/mdoc +test +doc version +mimaReportBinaryIssues

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           app_id: 162267
           private_key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
-
+      - uses: sbt/setup-sbt@v1
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:


### PR DESCRIPTION
Because sbt is no longer bundled in the Github Ubuntu runner, we need to "import it" explicitly in the actions.

All the dependency updates and releases are blocked until we merge this.