### PR TITLE
Change ownership of the repository to the teams that use it

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,5 @@
 # the repo. Unless a later match takes precedence,
 # mentioned account names will be requested for
 # review when someone opens a pull request.
-* @markus1189 @joroKr21 @m-dobler @CristinaHG @saeltz @houcros
+* @alexandra-moia @elbaulp @grollinger @ricsmania @paul-danilin-moia
+* @nvnkmrpdy @LukasL97 @sapizhak @eoatley @mzagorski-moia


### PR DESCRIPTION
The CODEOWNERS file is very outdated. This changes the ownership to the internal MOIA teams that are using this repository.