### PR TITLE
Update publishing code after Sonatype migration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,16 +98,17 @@ lazy val scalaFmtSettings = Seq(
   scalafmtOnCompile := true
 )
 
-lazy val sonatypeSettings = {
-  import xerial.sbt.Sonatype._
-  Seq(
-    publishTo              := sonatypePublishTo.value,
-    sonatypeProfileName    := organization.value,
-    publishMavenStyle      := true,
-    sonatypeProjectHosting := Some(GitHubHosting("moia-oss", "scynamo", "oss-support@moia.io")),
-    credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
-  )
-}
+// Reference: https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html
+lazy val sonatypeSettings = Seq(
+  publishTo := {
+    if (isSnapshot.value) Some("central-snapshots".at("https://central.sonatype.com/repository/maven-snapshots/"))
+    else localStaging.value
+  },
+  // Remove all additional repository other than Maven Central from POM
+  pomIncludeRepository := { _ => false },
+  publishMavenStyle    := true,
+  credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
+)
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts := Set.empty

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"    % "2.6.0")
 addSbtPlugin("com.github.sbt" % "sbt-git"         % "2.1.0")
 addSbtPlugin("org.scalameta"  % "sbt-mdoc"        % "2.9.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"    % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp"         % "2.3.1")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "1.1.5")


### PR DESCRIPTION
There were some changes to Sonatype[^1]: OSSRH was sunset, and we're supposed to publish to Central Sonatype now. For that reason, sbt-sonatype is no longer functional, and we need to adjust the publishing code as described in the sbt docs[^2].

[^1]: https://central.sonatype.org/pages/ossrh-eol/#central-support
[^2]: https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html