### PR TITLE
Add developer to sonatypeSettings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,6 +107,14 @@ lazy val sonatypeSettings = Seq(
   // Remove all additional repository other than Maven Central from POM
   pomIncludeRepository := { _ => false },
   publishMavenStyle    := true,
+  developers := List(
+    Developer(
+      id = "Ignacio Lucero",
+      name = "Ignacio Lucero",
+      email = "ignacio.lucero@moia.io",
+      url = url("http://moia.io")
+    )
+  ),
   credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
 )
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -12,5 +12,5 @@ To publish a release to Maven Central follow these steps:
    Note that your Sonatype credentials needs to be configured on your machine and you need to have access writes to publish artifacts to the group id `io.moia`.
 3. Release artifact to Maven Central with:
    ```
-   sbt +sonatypeRelease
+   sbt +sonaRelease
    ```


### PR DESCRIPTION
Otherwise, the `sonaRelease` step fails:
> Developers information is missing

Also, update the docs, because `sonatypeRelease` is now `sonaRelease`.